### PR TITLE
Remove the postinstall closure-util update

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "homepage": "https://openlayers.org/",
   "scripts": {
     "install": "node tasks/install.js",
-    "postinstall": "closure-util update",
     "start": "node tasks/serve.js",
     "lint": "eslint tasks test src examples transforms",
     "lint-package": "eslint --fix build/package",


### PR DESCRIPTION
Since closure-utils 1.0 the update is also a post install to update the library.

Having them both seem to be causing intermittent issues while doing `npm install` where it's seems to be possible for both `postinstall` scripts to start simultaneously and causing one to fail after the download because the destination folder already exists.

Here's a sample of the error code:
```
#17 321.0 npm ERR! code 1
#17 321.0 npm ERR! path /app/node_modules/closure-util
#17 321.0 npm ERR! command failed
#17 321.0 npm ERR! command sh -c -- node ./bin/closure-util.js update
#17 321.0 npm ERR! info install Downloading http://dl.google.com/closure-compiler/compiler-20171112.zip
#17 321.0 npm ERR! info install Downloading http://github.com/google/closure-library/archive/v20170910.zip
#17 321.0 npm ERR! info install Download complete: /app/node_modules/closure-util/.deps/compiler/5eb2c411b449e9f3d879be0f59139cb5b2894c09
#17 321.0 npm ERR! ERR! closure-util EEXIST: file already exists, mkdir '/app/node_modules/closure-util/.deps/library/947e46b02fd5e472c2daa86669c09303ca3e7033/closure-library-20170910/closure/bin/labs/code'
```

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
